### PR TITLE
feat: Send mail with tag name

### DIFF
--- a/src/DirectMailTransport.php
+++ b/src/DirectMailTransport.php
@@ -132,11 +132,11 @@ class DirectMailTransport extends Transport
             'SignatureVersion' => '1.0',
             'SignatureNonce' => \uniqid(),
             'RegionId' => $region['id'],
+            'TagName' => $this->getTagName($message)
         ]);
 
         $bodyName = $this->getBodyName($message);
         $parameters[$bodyName] = $message->getBody();
-
         $parameters['Signature'] = $this->makeSignature($parameters);
 
         return $parameters;
@@ -247,5 +247,21 @@ class DirectMailTransport extends Transport
     protected function getBodyName(Swift_Mime_SimpleMessage $message)
     {
         return $message->getBodyContentType() == 'text/plain' ? 'TextBody' : 'HtmlBody';
+    }
+
+    /**
+     * @param Swift_Mime_SimpleMessage $message
+     *
+     * @return string|null
+     */
+    protected function getTagName(Swift_Mime_SimpleMessage $message)
+    {
+        $messageHeaders = $message->getHeaders();
+        if ($messageHeaders->has('X-Tag-Name') == false) {
+            return null;
+        }
+        $tagName = $messageHeaders->get('X-Tag-Name')->getFieldBodyModel();
+        $messageHeaders->remove('X-Tag-Name');
+        return $tagName;
     }
 }

--- a/src/HasTagName.php
+++ b/src/HasTagName.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace Overtrue\LaravelMailAliyun;
+
+use Swift_Mime_SimpleMessage;
+
+/**
+ * Trait HasTagName
+ */
+trait HasTagName
+{
+    /**
+     * The callbacks for the message.
+     *
+     * @var array
+     */
+    public $callbacks = [];
+
+    /**
+     * @param $tagName
+     *
+     * @return \Closure
+     */
+    protected function getMailableCallback($tagName)
+    {
+        return function (Swift_Mime_SimpleMessage $message) use ($tagName) {
+            $message->getHeaders()->addTextHeader('X-Tag-Name', $tagName);
+        };
+    }
+
+    /**
+     * @param $tagName
+     *
+     * @return $this
+     */
+    public function tagName($tagName)
+    {
+        $this->callbacks['X-Tag-Name'] = $this->getMailableCallback($tagName);
+        return $this;
+    }
+}


### PR DESCRIPTION
for example
```
use Overtrue\LaravelMailAliyun\HasTagName;
class VerifyMail extend Mailable{
    use HasTagName;
    public function build()
    {
        return $this->tagName('alreadyDefinedTag')->text('mails.verify');
    }
}
```